### PR TITLE
Preview mode theme does not match edit theme

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -534,19 +534,19 @@ body.theme-dark {
 }
 
 /*** Headings ***/
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-1.cm-line {font-size: var(--size-h1); line-height: 1.2;}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-2.cm-line {font-size: var(--size-h2);}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-3.cm-line {font-size: var(--size-h3);}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-4.cm-line {font-size: var(--size-h4);}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-5.cm-line {font-size: var(--size-h5);}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-6.cm-line {font-size: var(--size-h6);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-1.cm-line, .markdown-rendered h1 {font-size: var(--size-h1); line-height: 1.2;}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-2.cm-line, .markdown-rendered h2 {font-size: var(--size-h2);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-3.cm-line, .markdown-rendered h3 {font-size: var(--size-h3);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-4.cm-line, .markdown-rendered h4 {font-size: var(--size-h4);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-5.cm-line, .markdown-rendered h5 {font-size: var(--size-h5);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-6.cm-line, .markdown-rendered h6 {font-size: var(--size-h6);}
 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-1.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-2.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-3.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-4.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-5.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-6.cm-line {
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-1.cm-line, .markdown-rendered h1,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-2.cm-line, .markdown-rendered h2,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-3.cm-line, .markdown-rendered h3,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-4.cm-line, .markdown-rendered h4,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-5.cm-line, .markdown-rendered h5,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-6.cm-line.markdown-rendered h6 {
   color: var(--heading-text-color);
   line-height: 1.2;
   padding-bottom: 15px;
@@ -628,7 +628,7 @@ Body text
 .external-link {background-position-y: 1px;}
 
 /* Lines of Text */
-.cm-contentContainer .cm-content .cm-line {
+.cm-contentContainer .cm-content .cm-line, .markdown-rendered {
   font-size: var(--font-paragraph); 
   font-family: var(--font-family-serif);
   line-height: 1.6;

--- a/obsidian.css
+++ b/obsidian.css
@@ -4,7 +4,7 @@ Version 1.1
 Created by @diegoeis
 
 Readme:
-https://github.com/diegoeis/obisidianotion
+https://github.com/diegoeis/obsidianotion
 ────────────────────────────────────────────────────── */
 
 /* @settings

--- a/theme.css
+++ b/theme.css
@@ -534,19 +534,19 @@ body.theme-dark {
 }
 
 /*** Headings ***/
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-1.cm-line {font-size: var(--size-h1); line-height: 1.2;}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-2.cm-line {font-size: var(--size-h2);}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-3.cm-line {font-size: var(--size-h3);}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-4.cm-line {font-size: var(--size-h4);}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-5.cm-line {font-size: var(--size-h5);}
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-6.cm-line {font-size: var(--size-h6);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-1.cm-line, .markdown-rendered h1 {font-size: var(--size-h1); line-height: 1.2;}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-2.cm-line, .markdown-rendered h2 {font-size: var(--size-h2);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-3.cm-line, .markdown-rendered h3 {font-size: var(--size-h3);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-4.cm-line, .markdown-rendered h4 {font-size: var(--size-h4);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-5.cm-line, .markdown-rendered h5 {font-size: var(--size-h5);}
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-6.cm-line, .markdown-rendered h6 {font-size: var(--size-h6);}
 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-1.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-2.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-3.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-4.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-5.cm-line, 
-.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-6.cm-line {
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-1.cm-line, .markdown-rendered h1,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-2.cm-line, .markdown-rendered h2,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-3.cm-line, .markdown-rendered h3,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-4.cm-line, .markdown-rendered h4,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-5.cm-line, .markdown-rendered h5,
+.cm-contentContainer .cm-content .HyperMD-header.HyperMD-header-6.cm-line.markdown-rendered h6 {
   color: var(--heading-text-color);
   line-height: 1.2;
   padding-bottom: 15px;
@@ -628,7 +628,7 @@ Body text
 .external-link {background-position-y: 1px;}
 
 /* Lines of Text */
-.cm-contentContainer .cm-content .cm-line {
+.cm-contentContainer .cm-content .cm-line, .markdown-rendered {
   font-size: var(--font-paragraph); 
   font-family: var(--font-family-serif);
   line-height: 1.6;

--- a/theme.css
+++ b/theme.css
@@ -4,7 +4,7 @@ Version 1.1
 Created by @diegoeis
 
 Readme:
-https://github.com/diegoeis/obisidianotion
+https://github.com/diegoeis/obsidianotion
 ────────────────────────────────────────────────────── */
 
 /* @settings


### PR DESCRIPTION
## Bug
Preview mode theme does not match edit mode theme

## Explanation
When switching to preview mode the theme reverts to the default obsidian theme. This makes it not play nice with plugins that utilize preview mode, such as [obsidian columns](https://github.com/tnichols217/obsidian-columns).

## Steps to reproduce
1. Switch to preview mode (CTRL+E)
2. View the reverting of the theme to the default obsidian theme

## Images
Images showing the current edit view and preview view. The columns are created utilizing obsidian columns plugin.
![Pasted image 20230731230516](https://github.com/diegoeis/obsidianotion/assets/61148588/bed5160d-edfc-4c5a-bd2c-69de8533ef64)
![Pasted image 20230731230447](https://github.com/diegoeis/obsidianotion/assets/61148588/58a13bda-8727-423b-857a-9bcd4f260b3b)

## What I've tried
1. Removed all other snippets
2. Parsed the code

## Changes/Fixes
- Fixed the preview text to match the edit theme
- Fixed the misspelled URL of the repository