### PR TITLE
Not show indentation guides issues.

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -433,7 +433,7 @@ Body Lists
   text-indent: 0;
 }
 
-.cm-indent::before {border: 0 !important;}
+.cm-indent::before {border: 1 !important;}
 
 div > ul,
 div > ol {


### PR DESCRIPTION
The theme doesn't show indentation guides by default but that's not good for editing, so I modified it to show it again.

Note that there is a problem with list indentation for this topic. Please solve the bug first, and then use this code to show the indentation guides
